### PR TITLE
Add systemd-sockets trigger to usysconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ sudo usysconf run -f
 | tmpfiles       | Update systemd tmpfiles                 |                                               |
 | systemd-reload | Reload systemd configuration            |                                               |
 | systemd-reexec | Re-execute systemd                      |                                               |
+| systemd-sockets| Re-start vendor-enabled .socket units   |                                               |
 | vbox-restart   | Restart VirtualBox services             | Will be replaced with generic service handler |
 | apparmor       | Compile AppArmor profiles               | Uses `aa-lsm-hook`                            |
 | glib2          | Compile glib-schemas                    |                                               |

--- a/src/context.c
+++ b/src/context.c
@@ -61,6 +61,7 @@ static const UscHandler *usc_handlers[] = {
         &usc_handler_sysusers,
         &usc_handler_tmpfiles,
         &usc_handler_systemd_reload,
+        &usc_handler_systemd_sockets,
 #ifdef HAVE_SYSTEMD_REEXEC
         &usc_handler_systemd_reexec,
 #endif

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -37,6 +37,7 @@ extern UscHandler usc_handler_ldm;
 extern UscHandler usc_handler_sysusers;
 extern UscHandler usc_handler_tmpfiles;
 extern UscHandler usc_handler_systemd_reload;
+extern UscHandler usc_handler_systemd_sockets;
 #ifdef HAVE_SYSTEMD_REEXEC
 extern UscHandler usc_handler_systemd_reexec;
 #endif

--- a/src/handlers/systemd/sockets.c
+++ b/src/handlers/systemd/sockets.c
@@ -1,0 +1,76 @@
+/*
+ * This file is part of usysconf.
+ *
+ * Copyright © 2020 Solus Project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include "config.h"
+#include "context.h"
+#include "files.h"
+#include "util.h"
+
+static const char *unit_paths[] = {
+        SYSTEMD_UNIT_DIR "/sockets.target.wants/" /* /usr/lib/systemd/system/sockets.target.wants/ */
+};
+
+/**
+ * Ask systemd to restart sockets.target when new vendor-enabled .socket units have been added/updated.
+ *
+ * This assumes that a daemon-reload has been performed first.
+ */
+static UscHandlerStatus usc_handler_systemd_sockets_exec(UscContext *ctx, const char *path)
+{
+        const char *command[] = {
+                "/usr/bin/systemctl", "restart", "sockets.target", NULL, /* Terminator */
+        };
+
+        if (access(path, X_OK) != 0) {
+                return USC_HANDLER_SKIP;
+        }
+
+        usc_context_emit_task_start(ctx, "Re-starting vendor-enabled .socket units");
+
+        if (usc_context_has_flag(ctx, USC_FLAGS_CHROOTED) ||
+            usc_context_has_flag(ctx, USC_FLAGS_LIVE_MEDIUM)) {
+                usc_context_emit_task_finish(ctx, USC_HANDLER_SKIP);
+                return USC_HANDLER_SKIP | USC_HANDLER_BREAK;
+        }
+
+        int ret = usc_exec_command((char **)command);
+        if (ret != 0) {
+                usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
+                return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
+        }
+        usc_context_emit_task_finish(ctx, USC_HANDLER_SUCCESS);
+        /* Only want to run once for all of our globs */
+        return USC_HANDLER_SUCCESS | USC_HANDLER_BREAK;
+}
+
+const UscHandler usc_handler_systemd_sockets = {
+        .name = "systemd-sockets",
+        .description = "Re-start systemd sockets.target",
+        .required_bin = "/usr/bin/systemctl",
+        .exec = usc_handler_systemd_sockets_exec,
+        .paths = unit_paths,
+        .n_paths = ARRAY_SIZE(unit_paths),
+};
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,6 +48,7 @@ if with_systemd == true
     handlers += [
         'systemd/tmpfiles',
         'systemd/sysusers',
+        'systemd/sockets',
         'systemd/reload',
     ]
     if with_systemd_reexec == true


### PR DESCRIPTION
This patch to usysconf adds a systemd-sockets trigger, which listens for
additions/changes to vendor-enabled .socket units installed to
`/usr/lib/systemd/system/sockets.target.wants/` and subsequently fires off
a `systemctl restart sockets.target`.

This has the effect of activating newly installed .socket units
immediately after installation. It also restarts any manually
deactivated vendor-enabled .socket units.

Prior to the addition of this trigger, newly installed vendor-enabled
.socket units would only be activated after a reboot.

It is expected that the `systemd-reload` trigger will run before the
`systemd-sockets` trigger.

Users wishing to run these triggers manually would do it like this:

`sudo usysconf run systemd-reload systemd-sockets -f`