### PR TITLE
Add trigger for gdk-pixbuf

### DIFF
--- a/examples/gdk-pixbuf.toml
+++ b/examples/gdk-pixbuf.toml
@@ -1,0 +1,13 @@
+description = "Update gdk-pixbuf cache"
+
+[check]
+paths = [
+    "/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders"
+]
+
+[[bins]]
+task = "Updating gdk-pixbuf cache"
+bin = "/usr/bin/gdk-pixbuf-query-loaders"
+args = [
+    "--update-cache"
+]


### PR DESCRIPTION
This PR adds a trigger, as requested by Staudey on the development portal, to automatically update the Gdk-PixBuf cache whenever a new image loader is detected in the relevant folder. This allows for the installation of additional loaders, such as the WebP loader I submitted for repository inclusion [here](https://dev.getsol.us/D13280).