### PR TITLE
Add ghc-pkg trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /state
+.cache

--- a/src/context.c
+++ b/src/context.c
@@ -99,6 +99,8 @@ static const UscHandler *usc_handlers[] = {
         &usc_handler_sshd,
 
         &usc_handler_udev_rules,
+
+        &usc_handler_ghc_pkg,
 };
 
 /**

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -73,6 +73,8 @@ extern UscHandler usc_handler_sshd;
 
 extern UscHandler usc_handler_udev_rules;
 
+extern UscHandler usc_handler_ghc_pkg;
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/src/handlers/ghc-pkg.c
+++ b/src/handlers/ghc-pkg.c
@@ -1,0 +1,70 @@
+/*
+ * This file is part of usysconf.
+ *
+ * Copyright © 2017-2019 Solus Project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include "context.h"
+#include "files.h"
+#include "util.h"
+
+static const char *library_paths[] = {
+        /* Match all Haskell package paths directories and run ghc-pkg for them */
+        "/usr/lib64/ghc-*",
+};
+
+/**
+ * Update the global Haskell package cache (`ghc-pkg recache`) when library directories update
+ */
+static UscHandlerStatus usc_handler_ghc_pkg_exec(UscContext *ctx, const char *path)
+{
+        char *command[] = {
+                "/usr/bin/ghc-pkg",
+                "recache",
+                "--global",
+                NULL, /* Terminator */
+        };
+
+        if (!usc_file_is_dir(path)) {
+                return USC_HANDLER_SKIP;
+        }
+
+        usc_context_emit_task_start(ctx, "Updating Haskell library cache");
+        int ret = usc_exec_command(command);
+        if (ret != 0) {
+                usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
+                return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
+        }
+        usc_context_emit_task_finish(ctx, USC_HANDLER_SUCCESS);
+        /* Only want to run once for all of our globs */
+        return USC_HANDLER_SUCCESS | USC_HANDLER_BREAK;
+}
+
+const UscHandler usc_handler_ghc_pkg = {
+        .name = "ghc-pkg",
+        .description = "Update Haskell library cache",
+        .required_bin = "/usr/bin/ghc-pkg",
+        .exec = usc_handler_ghc_pkg_exec,
+        .paths = library_paths,
+        .n_paths = ARRAY_SIZE(library_paths),
+};
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ xdg_handlers = [
 ]
 
 handlers = [
+    'ghc-pkg',
     'ldconfig',
     'hwdb',
     'mandb',


### PR DESCRIPTION
Add package to trigger caching for Haskell packages, otherwise users can get confused as to why they can't use installed packages in their code and we have to do [this](https://github.com/getsolus/ypkg/blob/72cedbc74fa77695fadad6699dd923be14c8ab15/ypkg2/rc.yml#L67) when building Haskell packages because the compiler doesn't know what packages have been installed.

Also add two little changes to the build system and git ignore. `.cache` is generated by Meson, and `default-library` has been renamed to `default_library`.