### PR TITLE
Use slog in place of waterlog

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-Present Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cli/graph.go
+++ b/cli/graph.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-Present Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cli/list.go
+++ b/cli/list.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-Present Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@ package cli
 
 import (
 	"fmt"
+	"log/slog"
 
-	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/usysconf/config"
 )
 
@@ -28,7 +28,7 @@ func (l list) Run(flags GlobalFlags) error {
 	if err != nil {
 		return fmt.Errorf("failed to load triggers: %w", err)
 	}
-	log.Info("Available triggers:\n\n")
+	slog.Info("Available triggers:")
 	tm.Print(flags.Chroot, flags.Live)
 	return nil
 }

--- a/cli/run.go
+++ b/cli/run.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-Present Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/usysconf/config"
 	"github.com/getsolus/usysconf/triggers"
 	"github.com/getsolus/usysconf/util"
@@ -33,9 +32,6 @@ type run struct {
 }
 
 func (r run) Run(flags GlobalFlags) error {
-	log.Debugln("Started usysconf")
-	defer log.Debugln("Exiting usysconf")
-
 	if os.Geteuid() != 0 {
 		return errors.New("you must have root privileges to run triggers")
 	}

--- a/deps/graph.go
+++ b/deps/graph.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
 package deps
 
 import (
-	log "github.com/DataDrake/waterlog"
+	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 )
@@ -46,7 +47,7 @@ func (g Graph) CheckMissing(triggers []string) {
 				}
 			}
 			if !found {
-				log.Warnf("Dependency '%s' of trigger '%s' does not exist\n", dep, name)
+				slog.Warn("Dependency does not exist", "parent", name, "child", dep)
 			}
 		}
 	}
@@ -64,7 +65,9 @@ func (g Graph) CheckCircular() {
 				}
 				found = found[1:]
 			}
-			log.Fatalf("Circular dependency: %s\n", strings.Join(found, " -> "))
+			// TODO: Return an error instead of panicking.
+			slog.Error("Circular dependency", "chain", strings.Join(found, " -> "))
+			panic("Circular dependency")
 		}
 	}
 }
@@ -168,13 +171,13 @@ func (g Graph) Print() {
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	log.Println("digraph {")
+	fmt.Println("digraph {")
 	for _, name := range names {
 		deps := g[name]
 		sort.Strings(deps)
 		for _, dep := range deps {
-			log.Printf("\t\"%s\" -> \"%s\";\n", name, dep)
+			fmt.Printf("\t\"%s\" -> \"%s\";\n", name, dep)
 		}
 	}
-	log.Println("}")
+	fmt.Println("}")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,11 @@
 module github.com/getsolus/usysconf
 
-go 1.20
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.3.2
-	github.com/DataDrake/waterlog v1.2.0
 	github.com/alecthomas/kong v0.8.0
 	github.com/fxamacker/cbor/v2 v2.5.0
 )
 
-require (
-	github.com/DataDrake/flair v0.5.1 // indirect
-	github.com/x448/float16 v0.8.4 // indirect
-)
+require github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/DataDrake/flair v0.5.1 h1:JHWOoBRiQGWg+k2bV2Mje2YmDtRjhMj51yDxQkzidWI=
-github.com/DataDrake/flair v0.5.1/go.mod h1:3KgdmkL8eJDbg/HdMwlHkeYH/mpSy/hsQvxYQFp9A/Y=
-github.com/DataDrake/waterlog v1.2.0 h1:T3Hs0D6YOQfz6GtViw+fYSIGpGimU41FubcxQQzaeHM=
-github.com/DataDrake/waterlog v1.2.0/go.mod h1:xSKEWChL8698jwSJSyjKPIpFpj/K5n+Eif2ztYXDjJI=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
 github.com/alecthomas/kong v0.8.0 h1:ryDCzutfIqJPnNn0omnrgHLbAggDQM2VWHikE1xqK7s=
 github.com/alecthomas/kong v0.8.0/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,25 +15,24 @@
 package main
 
 import (
-	log2 "log"
+	"log/slog"
+	"os"
 
-	log "github.com/DataDrake/waterlog"
-	"github.com/DataDrake/waterlog/format"
-	"github.com/DataDrake/waterlog/level"
 	"github.com/getsolus/usysconf/cli"
 )
 
 func main() {
 	ctx, flags := cli.Parse()
 
+	logOpt := &slog.HandlerOptions{}
 	if flags.Debug {
-		log.SetLevel(level.Debug)
+		logOpt.Level = slog.LevelDebug
 	}
-	log.SetFormat(format.Min)
-	log.SetFlags(log2.Ltime | log2.Ldate | log2.LUTC)
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, logOpt)))
 
 	err := ctx.Run(flags)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(err.Error())
+		os.Exit(1)
 	}
 }

--- a/state/map.go
+++ b/state/map.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@ package state
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
-	log "github.com/DataDrake/waterlog"
-	cbor "github.com/fxamacker/cbor/v2"
+	"github.com/fxamacker/cbor/v2"
 )
 
 // Path is the location of the serialized system state directory
@@ -110,7 +110,7 @@ func (m Map) Search(paths []string) Map {
 		search = "^" + strings.ReplaceAll(search, string(filepath.Separator), "\\"+string(filepath.Separator))
 		regex, err := regexp.Compile(search)
 		if err != nil {
-			log.Warnf("Could not convert path to regex: %s\n", path)
+			slog.Warn("Could not convert to regex", "path", path)
 			continue
 		}
 		for k, v := range m {
@@ -133,7 +133,7 @@ func (m Map) Exclude(patterns []string) Map {
 		exclude := strings.ReplaceAll(pattern, "*", ".*")
 		regex, err := regexp.Compile(exclude)
 		if err != nil {
-			log.Warnf("Could not convert pattern to regex: %s\n", pattern)
+			slog.Warn("Could not convert to regex", "pattern", pattern)
 			continue
 		}
 		regexes = append(regexes, regex)

--- a/triggers/bin.go
+++ b/triggers/bin.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@ package triggers
 import (
 	"bytes"
 	"fmt"
-	log "github.com/DataDrake/waterlog"
-	"github.com/getsolus/usysconf/util"
+	"log/slog"
 	"os/exec"
+
+	"github.com/getsolus/usysconf/util"
 )
 
 // Bin contains the details of the binary to be executed.
@@ -92,10 +93,10 @@ func (b Bin) FanOut() (nbins []Bin, outputs []Output) {
 		return
 	}
 	if b.Replace == nil {
-		log.Errorln("    Placeholder found, but [bins.replaces] is missing.")
+		slog.Error("Placeholder found, but [bins.replaces] is missing")
 		return
 	}
-	log.Debugf("    Replace string exists at arg: %d\n", phIndex)
+	slog.Debug("Replace string exists", "argument", phIndex)
 	paths := util.FilterPaths(b.Replace.Paths, b.Replace.Exclude)
 	for _, path := range paths {
 		out := Output{

--- a/triggers/check.go
+++ b/triggers/check.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@ package triggers
 
 import (
 	"fmt"
-	log "github.com/DataDrake/waterlog"
+	"log/slog"
+
 	"github.com/getsolus/usysconf/state"
 )
 
@@ -30,7 +31,7 @@ type Check struct {
 func (t *Trigger) CheckMatch() (m state.Map, ok bool) {
 	ok = true
 	if t.Check == nil {
-		log.Debugf("No check paths for trigger '%s'\n", t.Name)
+		slog.Debug("No check paths for trigger", "name", t.Name)
 		return
 	}
 	m, err := state.Scan(t.Check.Paths)

--- a/triggers/map.go
+++ b/triggers/map.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@ package triggers
 
 import (
 	"fmt"
+	"log/slog"
 	"sort"
 
-	log "github.com/DataDrake/waterlog"
 	"github.com/getsolus/usysconf/deps"
 	"github.com/getsolus/usysconf/state"
 )
@@ -53,9 +53,9 @@ func (tm Map) Print(chroot, live bool) {
 				continue
 			}
 		}
-		log.Printf(f, t.Name, t.Description)
+		fmt.Printf(f, t.Name, t.Description)
 	}
-	log.Println()
+	fmt.Println()
 }
 
 // Graph generates a dependency graph
@@ -82,7 +82,7 @@ func (tm Map) Run(s Scope, names []string) {
 	prev, err := state.Load()
 
 	if err != nil {
-		log.Errorf("Failed to read state file: %s\n", err)
+		slog.Error("Failed to read state file", "reason", err)
 		return
 	}
 
@@ -95,7 +95,7 @@ func (tm Map) Run(s Scope, names []string) {
 		// Get Trigger if available
 		t, ok := tm[name]
 		if !ok {
-			log.Warnf("Could not find trigger %s\n", name)
+			slog.Warn("Could not find trigger", "name", name)
 			continue
 		}
 		// Run Trigger
@@ -104,7 +104,7 @@ func (tm Map) Run(s Scope, names []string) {
 	if !s.DryRun {
 		// Save new State for next run
 		if err := next.Save(); err != nil {
-			log.Errorf("Failed to save next state file, reason: %s\n", err)
+			slog.Error("Failed to save next state file", "reason", err)
 		}
 	}
 }

--- a/triggers/remove.go
+++ b/triggers/remove.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,10 @@ package triggers
 
 import (
 	"fmt"
-	log "github.com/DataDrake/waterlog"
-	"github.com/getsolus/usysconf/state"
+	"log/slog"
 	"os"
+
+	"github.com/getsolus/usysconf/state"
 )
 
 // Remove contains paths to be removed from the system. This supports globbing.
@@ -30,10 +31,10 @@ type Remove struct {
 // Remove glob the paths and if it exists it will remove it from the system
 func (t *Trigger) Remove(s Scope) bool {
 	if s.DryRun {
-		log.Debugln("   No Paths will be removed during a dry-run\n")
+		slog.Debug("No Paths will be removed during a dry-run")
 	}
 	if len(t.Removals) == 0 {
-		log.Debugln("   No Paths to remove\n")
+		slog.Debug("No Paths to remove")
 		return true
 	}
 	for _, remove := range t.Removals {
@@ -57,7 +58,7 @@ func (t *Trigger) removeOne(s Scope, remove Remove) bool {
 	}
 	matches = matches.Exclude(remove.Exclude)
 	for path := range matches {
-		log.Debugf("    Removing path '%s'\n", path)
+		slog.Debug("Removing", "path", path)
 		if s.DryRun {
 			continue
 		}

--- a/triggers/trigger.go
+++ b/triggers/trigger.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
 package triggers
 
 import (
-	log "github.com/DataDrake/waterlog"
+	"log/slog"
+
 	"github.com/getsolus/usysconf/state"
 )
 
@@ -72,30 +73,30 @@ func (t *Trigger) Finish(s Scope) {
 	// Indicate the worst status for the whole group
 	switch status {
 	case Skipped:
-		log.Debugln(t.Name)
+		slog.Debug(t.Name)
 	case Failure:
-		log.Errorln(t.Name)
+		slog.Error(t.Name)
 	case Success:
-		log.Goodln(t.Name)
+		slog.Info(t.Name)
 	}
 	// Indicate status for sub-tasks
 	for _, out := range t.Output {
 		switch out.Status {
 		case Skipped:
 			if len(out.SubTask) > 0 {
-				log.Debugf("    Skipped for %s due to %s\n", out.SubTask, out.Message)
+				slog.Debug("Skipped", "subtask", out.SubTask, "reason", out.Message)
 			} else if len(out.Message) > 0 {
-				log.Debugf("    Skipped due to %s\n", out.Message)
+				slog.Debug("Skipped", "reason", out.Message)
 			}
 		case Failure:
 			if len(out.SubTask) > 0 {
-				log.Errorf("    Failure for %s due to %s\n", out.SubTask, out.Message)
+				slog.Error("Failed", "subtask", out.SubTask, "reason", out.Message)
 			} else if len(out.Message) > 0 {
-				log.Errorf("    Failure due to %s\n", out.Message)
+				slog.Error("Failed", "reason", out.Message)
 			}
 		case Success:
 			if s.DryRun && len(out.SubTask) > 0 {
-				log.Infof("    %s\n", out.SubTask)
+				slog.Info(out.SubTask)
 			}
 		}
 	}

--- a/util/live.go
+++ b/util/live.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2020 Solus Project
+// Copyright © Solus Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 package util
 
 import (
-	log "github.com/DataDrake/waterlog"
+	"log/slog"
 	"os"
 )
 
@@ -23,12 +23,14 @@ import (
 func IsLive() bool {
 	var err error
 	if _, err = os.Stat("/run/initramfs/livedev"); err == nil {
-		log.Debugln("Live session detected.")
+		slog.Debug("Live session detected")
 		return true
 	}
 	if os.IsNotExist(err) {
 		return false
 	}
-	log.Fatalf("Could not check for live session, reason: %s\n", err)
-	return false
+	slog.Error("Could not check for live session", "reason", err)
+	// TODO: Return error instead of panicking.
+	panic("Could not check for live session")
+	//return false
 }


### PR DESCRIPTION
slog is the new structured logging library from the Go project itself. It is available as an experimental package for Go 1.20 and was upstreamed in Go 1.21. This makes it a perfect candidate for our tooling, because:

- it won't bit-rot
- we can use a human-appealing Handler for CLI, and e.g. a JSON Handler on our builders, without changing the code

This PR only replaces waterlog with slog, using its TextHandler Handler. TextHandler is nowhere near the look of waterlog, but a custom Handler mimicking the old look is in the works and will come with a different PR in the near future.