### PR TITLE
Add handler for GIO modules

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -76,6 +76,7 @@ static const UscHandler *usc_handlers[] = {
 
         /** Enter userspace. */
         &usc_handler_glib2,
+        &usc_handler_glib2_gio,
         &usc_handler_gdk_pixbuf,
         &usc_handler_fonts,
         &usc_handler_mime,

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -51,6 +51,7 @@ extern UscHandler usc_handler_apparmor;
 #endif
 
 extern UscHandler usc_handler_glib2;
+extern UscHandler usc_handler_glib2_gio;
 extern UscHandler usc_handler_gdk_pixbuf;
 extern UscHandler usc_handler_fonts;
 extern UscHandler usc_handler_mime;

--- a/src/handlers/xdg/glib2-gio.c
+++ b/src/handlers/xdg/glib2-gio.c
@@ -1,0 +1,71 @@
+/*
+ * This file is part of usysconf.
+ *
+ * Copyright © 2017-2019 Solus Project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include "context.h"
+#include "files.h"
+#include "util.h"
+
+static const char *gio_modules_paths[] = {
+        "/usr/lib64/gio/modules/",
+};
+
+/**
+ * Create a module cache with metadata from gio modules. Without this gio has to open each module which can cause bugs.
+ */
+static UscHandlerStatus usc_handler_glib2_gio_exec(__usc_unused__ UscContext *ctx, const char *path)
+{
+        autofree(char) *fp = NULL;
+        char *command[] = {
+                "/usr/bin/gio-querymodules",
+                NULL, /* /usr/lib64/gio/modules */
+                NULL, /* Terminator */
+        };
+
+        if (!usc_file_is_dir(path)) {
+                return USC_HANDLER_SKIP;
+        }
+
+        command[1] = (char *)path,
+
+        usc_context_emit_task_start(ctx, "Creating GIO modules cache");
+        int ret = usc_exec_command(command);
+        if (ret != 0) {
+                usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
+                return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
+        }
+        usc_context_emit_task_finish(ctx, USC_HANDLER_SUCCESS);
+        /* Only want to run once for all of our globs */
+        return USC_HANDLER_SUCCESS | USC_HANDLER_BREAK;
+}
+
+const UscHandler usc_handler_glib2_gio = {
+        .name = "glib2-gio",
+        .description = "Create glib2 GIO modules cache",
+        .required_bin = "/usr/bin/gio-querymodules",
+        .exec = usc_handler_glib2_gio_exec,
+        .paths = gio_modules_paths,
+        .n_paths = ARRAY_SIZE(gio_modules_paths),
+};
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,7 @@ xdg_handlers = [
     'gconf',
     'gdk-pixbuf',
     'glib2',
+    'glib2-gio',
     'mime',
     'icon-cache',
     'fonts',


### PR DESCRIPTION
This creates a GIO modules cache from all installed GIO modules. If this isn't present then Glib2 code needs to start each module even if it doesn't need it, and in certain circumstances this can cause issues. For instance, GTK2 apps had a startup delay due to a DBUS timeout caused by the DBUS connection leaking between modules and being closed in one module while another still depended on it.

Reference: getsolus/packages#540