### PR TITLE
legacy: Add vlc handler

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -84,6 +84,7 @@ static const UscHandler *usc_handlers[] = {
         &usc_handler_desktop_files,
         &usc_handler_gconf,
         &usc_handler_dconf,
+        &usc_handler_vlc,
 
         /* GTK immodules */
         &usc_handler_gtk2_immodules,

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -59,6 +59,7 @@ extern UscHandler usc_handler_icon_cache;
 extern UscHandler usc_handler_desktop_files;
 extern UscHandler usc_handler_gconf;
 extern UscHandler usc_handler_dconf;
+extern UscHandler usc_handler_vlc;
 
 extern UscHandler usc_handler_gtk2_immodules;
 extern UscHandler usc_handler_gtk3_immodules;

--- a/src/handlers/vlc.c
+++ b/src/handlers/vlc.c
@@ -23,7 +23,7 @@ static const char *vlc_modules_paths[] = {
 /**
  * Create a VLC plugin cache
  */
-static UscHandlerStatus usc_handler_vlc_exec(__usc_unused__ UscContext *ctx, const char *path)
+static UscHandlerStatus usc_handler_vlc_exec(UscContext *ctx, const char *path)
 {
         autofree(char) *fp = NULL;
         char *command[] = {

--- a/src/handlers/vlc.c
+++ b/src/handlers/vlc.c
@@ -1,0 +1,72 @@
+/*
+ * This file is part of usysconf.
+ *
+ * Copyright © 2017-2019 Solus Project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include "context.h"
+#include "files.h"
+#include "util.h"
+
+static const char *vlc_modules_paths[] = {
+        "/usr/lib/vlc/plugins/",
+        "/usr/lib64/vlc/plugins/",
+};
+
+/**
+ * Create a VLC plugin cache
+ */
+static UscHandlerStatus usc_handler_vlc_exec(__usc_unused__ UscContext *ctx, const char *path)
+{
+        autofree(char) *fp = NULL;
+        char *command[] = {
+                "/usr/lib64/vlc/vlc-cache-gen",
+                NULL, /* /usr/lib64/vlc/plugins/ */
+                NULL, /* Terminator */
+        };
+
+        if (!usc_file_is_dir(path)) {
+                return USC_HANDLER_SKIP;
+        }
+
+        command[1] = (char *)path,
+
+        usc_context_emit_task_start(ctx, "Creating VLC plugins cache");
+        int ret = usc_exec_command(command);
+        if (ret != 0) {
+                usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
+                return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
+        }
+        usc_context_emit_task_finish(ctx, USC_HANDLER_SUCCESS);
+        /* Only want to run once for all of our globs */
+        return USC_HANDLER_SUCCESS | USC_HANDLER_BREAK;
+}
+
+const UscHandler usc_handler_vlc = {
+        .name = "vlc",
+        .description = "Create VLC Plugins cache",
+        .required_bin = "/usr/lib64/vlc/vlc-cache-gen",
+        .exec = usc_handler_vlc_exec,
+        .paths = vlc_modules_paths,
+        .n_paths = ARRAY_SIZE(vlc_modules_paths),
+};
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/handlers/vlc.c
+++ b/src/handlers/vlc.c
@@ -25,21 +25,18 @@ static const char *vlc_modules_paths[] = {
  */
 static UscHandlerStatus usc_handler_vlc_exec(UscContext *ctx, const char *path)
 {
-        autofree(char) *fp = NULL;
-        char *command[] = {
-                "/usr/lib64/vlc/vlc-cache-gen",
-                NULL, /* /usr/lib64/vlc/plugins/ */
-                NULL, /* Terminator */
-        };
-
         if (!usc_file_is_dir(path)) {
                 return USC_HANDLER_SKIP;
         }
 
-        command[1] = (char *)path,
+        const char *command[] = {
+                "/usr/lib64/vlc/vlc-cache-gen",
+                path, /* /usr/lib64/vlc/plugins/ */
+                NULL, /* Terminator */
+        };
 
         usc_context_emit_task_start(ctx, "Creating VLC plugins cache");
-        int ret = usc_exec_command(command);
+        int ret = usc_exec_command((char **) command);
         if (ret != 0) {
                 usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
                 return USC_HANDLER_FAIL | USC_HANDLER_BREAK;

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ handlers = [
     'mandb',
     'ssl',
     'udev-rules',
+    'vlc',
 ]
 
 kernel_handlers = [


### PR DESCRIPTION
Given that we're not yet migrated to the go usysconf we might as well add a VLC plugins cache since we're using VLC as the phonon provider on Plasma.