### PR TITLE
handlers/systemd: Add trigger for systemd presets

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -60,6 +60,8 @@ static const UscHandler *usc_handlers[] = {
 #ifdef HAVE_SYSTEMD
         &usc_handler_sysusers,
         &usc_handler_tmpfiles,
+        &usc_handler_system_presets,
+        &usc_handler_user_presets,
         &usc_handler_systemd_reload,
         &usc_handler_systemd_sockets,
 #ifdef HAVE_SYSTEMD_REEXEC

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -34,6 +34,8 @@ extern UscHandler usc_handler_ldm;
 #endif
 
 #ifdef HAVE_SYSTEMD
+extern UscHandler usc_handler_system_presets;
+extern UscHandler usc_handler_user_presets;
 extern UscHandler usc_handler_sysusers;
 extern UscHandler usc_handler_tmpfiles;
 extern UscHandler usc_handler_systemd_reload;

--- a/src/handlers/systemd/presets.c
+++ b/src/handlers/systemd/presets.c
@@ -1,0 +1,120 @@
+/*
+ * This file is part of usysconf.
+ *
+ * Copyright © 2026 Solus Project
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include "context.h"
+#include "files.h"
+#include "util.h"
+
+#include <string.h>
+
+static const char *system_presets_paths[] = {
+    "/usr/lib32/systemd/system/*.service",
+    "/usr/lib64/systemd/system/*.service"
+};
+
+static const char *user_presets_paths[] = {
+    "/usr/lib32/systemd/user/*.service",
+    "/usr/lib64/systemd/user/*.service"
+};
+
+static UscHandlerStatus usc_handler_system_presets_exec(UscContext *context, const char *path) {
+    if (!usc_file_exists(path)) {
+        return USC_HANDLER_SKIP;
+    }
+
+    usc_context_emit_task_start(context, "Updating systemd system service presets");
+
+    const char *service_name = basename(path);
+
+    const char *command[] = {
+        "/usr/bin/systemctl",
+        "preset",
+        service_name,
+        "--root=/", /* Ensure no tom-foolery with dbus */
+        "--force",
+        NULL        /* Terminator */
+    };
+
+    int ret = usc_exec_command((char **) command);
+
+    if (ret != 0) {
+        usc_context_emit_task_finish(context, USC_HANDLER_FAIL);
+        return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
+    }
+
+    usc_context_emit_task_finish(context, USC_HANDLER_SUCCESS);
+    /* Only want to run once for all of our globs */
+    return USC_HANDLER_SUCCESS | USC_HANDLER_BREAK;
+}
+
+static UscHandlerStatus usc_handler_user_presets_exec(UscContext *context, const char *path) {
+    if (!usc_file_exists(path)) {
+        return USC_HANDLER_SKIP;
+    }
+
+    usc_context_emit_task_start(context, "Updating systemd user service presets");
+
+    const char *service_name = basename(path);
+
+    const char *command[] = {
+        "/usr/bin/systemctl",
+        "preset",
+        service_name,
+        "--root=/", /* Ensure no tom-foolery with dbus */
+        "--force",
+        "--global",
+        NULL        /* Terminator */
+    };
+
+    int ret = usc_exec_command((char **) command);
+
+    if (ret != 0) {
+        usc_context_emit_task_finish(context, USC_HANDLER_FAIL);
+        return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
+    }
+
+    usc_context_emit_task_finish(context, USC_HANDLER_SUCCESS);
+    /* Only want to run once for all of our globs */
+    return USC_HANDLER_SUCCESS | USC_HANDLER_BREAK;
+}
+
+const UscHandler usc_handler_system_presets = {
+    .name = "system-presets",
+    .description = "Update systemd system service presets",
+    .required_bin = "/usr/bin/systemctl",
+    .exec = usc_handler_system_presets_exec,
+    .paths = system_presets_paths,
+    .n_paths = ARRAY_SIZE(system_presets_paths),
+};
+
+const UscHandler usc_handler_user_presets = {
+    .name = "user-presets",
+    .description = "Update systemd user service presets",
+    .required_bin = "/usr/bin/systemctl",
+    .exec = usc_handler_user_presets_exec,
+    .paths = user_presets_paths,
+    .n_paths = ARRAY_SIZE(user_presets_paths),
+};
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,6 +49,7 @@ endif
 # We'll still enable hwdb but alter for udev path if not using systemd
 if with_systemd == true
     handlers += [
+        'systemd/presets',
         'systemd/tmpfiles',
         'systemd/sysusers',
         'systemd/sockets',


### PR DESCRIPTION
This adds triggers to configure systemd services according to [systemd presets](https://www.freedesktop.org/software/systemd/man/latest/systemd.preset.html).

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
