### PR TITLE
handlers: Set presets for qol-assist and vbox

### DIFF
--- a/src/handlers/qol-assist.c
+++ b/src/handlers/qol-assist.c
@@ -12,7 +12,6 @@
 #define _GNU_SOURCE
 
 #include "context.h"
-#include "files.h"
 #include "util.h"
 
 /**
@@ -34,7 +33,8 @@ static const char *qol_paths[] = {
  * This will follow a versioned migration, and will happily ignore any
  * migrations that already happened.
  */
-static UscHandlerStatus usc_handler_qol_assist_exec(UscContext *ctx, const char *path)
+static UscHandlerStatus usc_handler_qol_assist_exec(UscContext *ctx,
+                                                    __usc_unused__ const char *path)
 {
         char *command[] = {
                 "/usr/sbin/qol-assist",
@@ -55,6 +55,22 @@ static UscHandlerStatus usc_handler_qol_assist_exec(UscContext *ctx, const char 
                 usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
                 return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
         }
+
+        const char *preset_command[] = {
+                "/usr/bin/systemctl",
+                "preset",
+                "qol-assist-migration.service",
+                "--root=/", /* Ensure no tom-foolery with dbus */
+                "--force",
+                NULL /* Terminator */
+        };
+
+        ret = usc_exec_command((char **)preset_command);
+        if (ret != 0) {
+                usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
+                return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
+        }
+
         usc_context_emit_task_finish(ctx, USC_HANDLER_SUCCESS);
         /* Only want to run once for all of our globs */
         return USC_HANDLER_SUCCESS | USC_HANDLER_BREAK;

--- a/src/handlers/systemd/vbox-restart.c
+++ b/src/handlers/systemd/vbox-restart.c
@@ -13,7 +13,6 @@
 
 #include "config.h"
 #include "context.h"
-#include "files.h"
 #include "util.h"
 
 static const char *unit_paths[] = {
@@ -40,6 +39,21 @@ static UscHandlerStatus usc_handler_vbox_restart_exec(UscContext *ctx,
         }
 
         int ret = usc_exec_command((char **)command);
+        if (ret != 0) {
+                usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
+                return USC_HANDLER_FAIL | USC_HANDLER_BREAK;
+        }
+
+        const char *preset_command[] = {
+                "/usr/bin/systemctl",
+                "preset",
+                "vboxdrv.service",
+                "--root=/", /* Ensure no tom-foolery with dbus */
+                "--force",
+                NULL /* Terminator */
+        };
+
+        ret = usc_exec_command((char **)preset_command);
         if (ret != 0) {
                 usc_context_emit_task_finish(ctx, USC_HANDLER_FAIL);
                 return USC_HANDLER_FAIL | USC_HANDLER_BREAK;


### PR DESCRIPTION
This will hopefully fix the problem where these service files were cached by usysconf before the preset triggers ran, thus causing the preset trigger to not get called for those files.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
