### PR TITLE
handlers/presets: Also trigger on target files

### DIFF
--- a/src/handlers/systemd/presets.c
+++ b/src/handlers/systemd/presets.c
@@ -19,9 +19,8 @@
 #include <string.h>
 
 static const char *system_presets_paths[] = {
-        "/usr/lib/systemd/system/*.path",
-        "/usr/lib/systemd/system/*.service",
-        "/usr/lib/systemd/system/*.socket",
+        "/usr/lib/systemd/system/*.path",   "/usr/lib/systemd/system/*.service",
+        "/usr/lib/systemd/system/*.socket", "/usr/lib/systemd/system/*.target",
         "/usr/lib/systemd/system/*.timer",
 };
 


### PR DESCRIPTION
Without it, some targets like `remote-fs` might not get enabled.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
