### PR TITLE
handlers/mandb: Run systemd trigger for mandb

### DIFF
--- a/src/handlers/mandb.c
+++ b/src/handlers/mandb.c
@@ -26,6 +26,10 @@ static const char *manpage_paths[] = {
 static UscHandlerStatus usc_handler_mandb_exec(UscContext *ctx, const char *path)
 {
         char *command[] = {
+                "/usr/bin/systemd-run",
+                "--unit=mandb-trigger",
+                "--nice=19", /* avoids the system feeling unnecessarily sluggish */
+                "--collect",
                 "/usr/bin/mandb",
                 "-q", /* keep it quiet */
                 NULL, /* Terminator */


### PR DESCRIPTION
Running mandb is blocking, and can be really slow if there are a lot of manpages to process. Running the systemd trigger means that we can "fire and forget", significantly speeding up package installation and upgrades.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
