### PR TITLE
handlers/mandb: Don't run in chroot

### DIFF
--- a/src/handlers/mandb.c
+++ b/src/handlers/mandb.c
@@ -39,6 +39,11 @@ static UscHandlerStatus usc_handler_mandb_exec(UscContext *ctx, const char *path
                 return USC_HANDLER_SKIP;
         }
 
+        if (usc_context_has_flag(ctx, USC_FLAGS_CHROOTED)) {
+                usc_context_emit_task_finish(ctx, USC_HANDLER_SKIP);
+                return USC_HANDLER_SKIP | USC_HANDLER_BREAK;
+        }
+
         usc_context_emit_task_start(ctx, "Updating manpages database");
         int ret = usc_exec_command(command);
         if (ret != 0) {


### PR DESCRIPTION
The current behaviour breaks building ISO images because in our setup, systemd is not PID 1, so it can't run the task. There is really no reason to run this trigger in a chroot environment; it only builds the caches for `whatis` and `apropos`.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
