### PR TITLE
fonts: Add fontconfig paths to fonts trigger

### DIFF
--- a/src/handlers/xdg/fonts.c
+++ b/src/handlers/xdg/fonts.c
@@ -18,6 +18,8 @@
 static const char *font_paths[] = {
         "/usr/share/fonts/*/*",
         "/usr/share/fonts/*",
+        "/usr/share/fontconfig/conf.avail/*",
+        "/usr/share/fontconfig/conf.default/*",
 };
 
 /**


### PR DESCRIPTION
It's a good idea to rebuild the font cache whenever the config files change. So let's do that.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
