### PR TITLE
fonts: Fix paths for fontconfig directories

### DIFF
--- a/src/handlers/xdg/fonts.c
+++ b/src/handlers/xdg/fonts.c
@@ -18,8 +18,8 @@
 static const char *font_paths[] = {
         "/usr/share/fonts/*/*",
         "/usr/share/fonts/*",
-        "/usr/share/fontconfig/conf.avail/*",
-        "/usr/share/fontconfig/conf.default/*",
+        "/usr/share/fontconfig/conf.avail",
+        "/usr/share/fontconfig/conf.default",
 };
 
 /**


### PR DESCRIPTION
I failed to notice the first time around that the trigger will skip running if the path it's given is not a directory. Removing the wildcards results in directories being matched when fontconfig updates.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
